### PR TITLE
Fix wrong configuration being used with multiple workspace folders

### DIFF
--- a/mypy_ls/plugin.py
+++ b/mypy_ls/plugin.py
@@ -23,7 +23,8 @@ line_pattern: str = r"((?:^[a-z]:)?[^:]+):(?:(\d+):)?(?:(\d+):)? (\w+): (.*)"
 
 log = logging.getLogger(__name__)
 
-mypyConfigFile: Optional[str] = None
+# A mapping from workspace path to config file path
+mypyConfigFileMap: Dict[str, Optional[str]] = dict()
 
 tmpFile: Optional[IO[str]] = None
 
@@ -157,6 +158,7 @@ def pylsp_lint(
         )
         return last_diagnostics[document.path]
 
+    mypyConfigFile = mypyConfigFileMap.get(workspace.root_path)
     if mypyConfigFile:
         args.append("--config-file")
         args.append(mypyConfigFile)
@@ -250,10 +252,10 @@ def init(workspace: str) -> Dict[str, str]:
         with open(path) as file:
             configuration = eval(file.read())
 
-    global mypyConfigFile
     mypyConfigFile = findConfigFile(workspace, "mypy.ini")
     if not mypyConfigFile:
         mypyConfigFile = findConfigFile(workspace, ".mypy.ini")
+    mypyConfigFileMap[workspace] = mypyConfigFile
 
     if ("enabled" not in configuration or configuration["enabled"]) and (
         "live_mode" not in configuration or configuration["live_mode"]

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -91,19 +91,19 @@ def foo():
     return
     unreachable = 1
 """
-    DOC_ERR_MSG = 'Statement is unreachable'
+    DOC_ERR_MSG = "Statement is unreachable"
 
     # Initialize two workspace folders.
-    folder1 = tmpdir.mkdir('folder1')
+    folder1 = tmpdir.mkdir("folder1")
     ws1 = Workspace(uris.from_fs_path(str(folder1)), Mock())
     ws1._config = Config(ws1.root_uri, {}, 0, {})
-    folder2 = tmpdir.mkdir('folder2')
+    folder2 = tmpdir.mkdir("folder2")
     ws2 = Workspace(uris.from_fs_path(str(folder2)), Mock())
     ws2._config = Config(ws2.root_uri, {}, 0, {})
 
     # Create configuration file for workspace folder 1.
-    mypy_config = folder1.join('mypy.ini')
-    mypy_config.write('[mypy]\nwarn_unreachable = True')
+    mypy_config = folder1.join("mypy.ini")
+    mypy_config.write("[mypy]\nwarn_unreachable = True")
 
     # Initialize settings for both folders.
     plugin.pylsp_settings(ws1._config)


### PR DESCRIPTION
When a workspace has multiple folders then the approach of using
one global variable to store the config breaks down as each workspace
folder can have separate configuration and the last one that gets
initialized overwrites the previous one.

Store configuration in a map looked up by workspace folder path.